### PR TITLE
Fix moving comments

### DIFF
--- a/__tests__/lib/rules/sort-keys-fix.js
+++ b/__tests__/lib/rules/sort-keys-fix.js
@@ -188,6 +188,13 @@ ruleTester.run('sort-keys-fix', rule, {
       output: 'var obj = {\n_:2, /* comment */\n a:1,\n b:3\n}',
     },
 
+    // Multiple comments fail currently
+    // {
+    //  code: 'var obj = {\na:1, // comment a\n _:2, // comment _\n b:3 // comment b\n}',
+    //  errors: ["Expected object keys to be in ascending order. '_' should be before 'a'."],
+    //  output: 'var obj = {\n_:2, // comment _\n a:1, // comment a\n b:3 // comment b\n}',
+    // },
+
     // default (asc)
     {
       code: 'var obj = {a:1, _:2, b:3} // default',

--- a/__tests__/lib/rules/sort-keys-fix.js
+++ b/__tests__/lib/rules/sort-keys-fix.js
@@ -175,12 +175,11 @@ ruleTester.run('sort-keys-fix', rule, {
   ],
   invalid: [
     // move comments on the same line as property together with property
-    // not implemented yet
-    // {
-    //   code: 'var obj = {\na:1,\n _:2, // comment\n b:3\n}',
-    //   errors: ["Expected object keys to be in ascending order. '_' should be before 'a'."],
-    //   output: 'var obj = {\n_:2, // comment\n a:1,\n b:3\n}',
-    // },
+    {
+      code: 'var obj = {\na:1,\n _:2, // comment\n b:3\n}',
+      errors: ["Expected object keys to be in ascending order. '_' should be before 'a'."],
+      output: 'var obj = {\n_:2, // comment\n a:1,\n b:3\n}',
+    },
 
     // default (asc)
     {

--- a/__tests__/lib/rules/sort-keys-fix.js
+++ b/__tests__/lib/rules/sort-keys-fix.js
@@ -181,6 +181,13 @@ ruleTester.run('sort-keys-fix', rule, {
       output: 'var obj = {\n_:2, // comment\n a:1,\n b:3\n}',
     },
 
+    // move comments on the same line as property together with property, multiline comment syntax
+    {
+      code: 'var obj = {\na:1,\n _:2, /* comment */\n b:3\n}',
+      errors: ["Expected object keys to be in ascending order. '_' should be before 'a'."],
+      output: 'var obj = {\n_:2, /* comment */\n a:1,\n b:3\n}',
+    },
+
     // default (asc)
     {
       code: 'var obj = {a:1, _:2, b:3} // default',

--- a/lib/rules/sort-keys-fix.js
+++ b/lib/rules/sort-keys-fix.js
@@ -159,7 +159,7 @@ module.exports = {
         if (!isValidOrder(prevName, thisName)) {
           context.report({
             node,
-            loc: node.key.loc, 
+            loc: node.key.loc,
             message:
               "Expected object keys to be in {{natual}}{{insensitive}}{{order}}ending order. '{{thisName}}' should be before '{{prevName}}'.",
             data: {
@@ -169,10 +169,27 @@ module.exports = {
               insensitive: insensitive ? 'insensitive ' : '',
               natual: natual ? 'natural ' : '',
             },
-            fix(fixer) { 
+            fix(fixer) {
               const sourceCode = context.getSourceCode()
               const thisText = sourceCode.getText(node)
               const prevText = sourceCode.getText(prevNode)
+
+              // Find inline comments on the line to be moved, and move them too
+              const commaToken = sourceCode.getTokenAfter(node)
+              const possibleComment = sourceCode.getTokenAfter(commaToken, { includeComments: true })
+              const prevNodeCommaToken = sourceCode.getTokenAfter(prevNode)
+
+              if (commaToken && commaToken.value === ',' && possibleComment && possibleComment.type === 'Line') {
+                return [
+                  fixer.replaceText(node, prevText),
+                  fixer.replaceText(prevNode, thisText),
+                  fixer.insertTextAfter(prevNodeCommaToken, ' //' + possibleComment.value),
+                  // Tried just removing the comment node: `fixer.remove(possibleComment)` but
+                  // that leaves a single whitespace at the end of the line.
+                  fixer.replaceTextRange([possibleComment.range[0] - 1, possibleComment.range[1]], ''),
+                ]
+              }
+
               return [fixer.replaceText(node, prevText), fixer.replaceText(prevNode, thisText)]
             },
           })

--- a/lib/rules/sort-keys-fix.js
+++ b/lib/rules/sort-keys-fix.js
@@ -179,11 +179,18 @@ module.exports = {
               const possibleComment = sourceCode.getTokenAfter(commaToken, { includeComments: true })
               const prevNodeCommaToken = sourceCode.getTokenAfter(prevNode)
 
-              if (commaToken && commaToken.value === ',' && possibleComment && possibleComment.type === 'Line') {
+              if (
+                commaToken &&
+                commaToken.value === ',' &&
+                possibleComment &&
+                (possibleComment.type === 'Line' || possibleComment.type === 'Block')
+              ) {
+                const comment =
+                  possibleComment.type === 'Line' ? ' //' + possibleComment.value : ' /*' + possibleComment.value + '*/'
                 return [
                   fixer.replaceText(node, prevText),
                   fixer.replaceText(prevNode, thisText),
-                  fixer.insertTextAfter(prevNodeCommaToken, ' //' + possibleComment.value),
+                  fixer.insertTextAfter(prevNodeCommaToken, comment),
                   // Tried just removing the comment node: `fixer.remove(possibleComment)` but
                   // that leaves a single whitespace at the end of the line.
                   fixer.replaceTextRange([possibleComment.range[0] - 1, possibleComment.range[1]], ''),


### PR DESCRIPTION
This is a WIP for fixing issue #2.
It handles simple cases of the second example in the ticket, but fails when each entry has a comment.  I'm leaving it here if someone is interested in picking it up, for our initial transformation I think we will go for this approach instead: https://github.com/JamieMason/codemods#sort-object-props