### PR TITLE
feat: move above comments together with property

### DIFF
--- a/__tests__/lib/rules/sort-keys-fix.js
+++ b/__tests__/lib/rules/sort-keys-fix.js
@@ -182,6 +182,20 @@ ruleTester.run('sort-keys-fix', rule, {
     //   output: 'var obj = {\n_:2, // comment\n a:1,\n b:3\n}',
     // },
 
+    // move inline comments on the line above property together with property
+    {
+      code: 'var obj = {\n// comment\n// comment 2\na:1,\n_:2,\nb:3\n}',
+      errors: ["Expected object keys to be in ascending order. '_' should be before 'a'."],
+      output: 'var obj = {\n\n\n_:2,\n// comment\n// comment 2\na:1,\nb:3\n}',
+    },
+
+    // move multiline comments on the line above property together with property
+    {
+      code: 'var obj = {\n/* comment\n comment 2 */\na:1,\n_:2,\nb:3\n}',
+      errors: ["Expected object keys to be in ascending order. '_' should be before 'a'."],
+      output: 'var obj = {\n\n_:2,\n/* comment\n comment 2 */\na:1,\nb:3\n}',
+    },
+
     // default (asc)
     {
       code: 'var obj = {a:1, _:2, b:3} // default',

--- a/lib/rules/sort-keys-fix.js
+++ b/lib/rules/sort-keys-fix.js
@@ -159,7 +159,7 @@ module.exports = {
         if (!isValidOrder(prevName, thisName)) {
           context.report({
             node,
-            loc: node.key.loc, 
+            loc: node.key.loc,
             message:
               "Expected object keys to be in {{natual}}{{insensitive}}{{order}}ending order. '{{thisName}}' should be before '{{prevName}}'.",
             data: {
@@ -169,11 +169,21 @@ module.exports = {
               insensitive: insensitive ? 'insensitive ' : '',
               natual: natual ? 'natural ' : '',
             },
-            fix(fixer) { 
+            fix(fixer) {
+              const fixes = []
               const sourceCode = context.getSourceCode()
-              const thisText = sourceCode.getText(node)
-              const prevText = sourceCode.getText(prevNode)
-              return [fixer.replaceText(node, prevText), fixer.replaceText(prevNode, thisText)]
+              const moveProperty = (fromNode, toNode) => {
+                const prevText = sourceCode.getText(fromNode)
+                const thisComments = sourceCode.getCommentsBefore(fromNode)
+                for (const thisComment of thisComments) {
+                  fixes.push(fixer.insertTextBefore(toNode, sourceCode.getText(thisComment) + '\n'))
+                  fixes.push(fixer.remove(thisComment))
+                }
+                fixes.push(fixer.replaceText(toNode, prevText))
+              }
+              moveProperty(node, prevNode)
+              moveProperty(prevNode, node)
+              return fixes
             },
           })
         }


### PR DESCRIPTION
Relates to #2

The difference from #2 relies on moving comment above instead of comments on the same line.

For me, it's more critical because I add comments above the properties. Also, it'll help with `// eslint-disable-next-line` comments

#### Known problems

The newline symbol from the comment remains. It should be easily fixed by prettier. I saw such policy in one of the used eslint plugins, so I hope it won't be a blocker to merge it: better remove extra new line than move comment manually