### PR TITLE
Add espree, esutils, and natural-compare to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "test-debug": "node --inspect node_modules/.bin/jest --watch --runInBand"
   },
   "dependencies": {
+    "espree": "^6.1.2",
+    "esutils": "^2.0.2",
+    "natural-compare": "^1.4.0",
     "requireindex": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Thanks for the awesome plugin!

However, I ran into the following error when using it in a Yarn 2 project. 

> Error: Failed to load plugin 'sort-keys-fix' declared in '.eslintrc.js': eslint-plugin-sort-keys-fix tried to access esutils, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

I have added these to the `package.json`. I mirrored exactly the versions that the `require` calls were actually resolving to, so this is why there are no changes to the `yarn.lock` file.

In the mean time, Yarn 2 users can add the following to their `.yarnrc.yml`

```yml
packageExtensions:
  eslint-plugin-sort-keys-fix@1.1.1:
    dependencies:
      esutils: '^2.0.2'
      espree: '^6.1.2'
      natural-compare: '^1.4.0'
```

https://yarnpkg.com/configuration/yarnrc#packageExtensions