### PR TITLE
Add missing undeclared dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "test-debug": "node --inspect node_modules/.bin/jest --watch --runInBand"
   },
   "dependencies": {
+    "espree": "^6.1.2",
+    "esutils": "^2.0.2",
+    "natural-compare": "^1.4.0",
     "requireindex": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm adding dependencies that are being require'd in the codebase, but not defined in `package.json`. This issue is detected by Yarn 2 (My config: Zero-Installs, `yarn dlx @yarnpkg/pnpify --sdk vscode`).

Temporary workaround, add in `.yarnrc.yml`:
```
packageExtensions:
  eslint-plugin-sort-keys-fix@*:
    dependencies:
      requireindex: "~1.2.0"
      espree: "^6.1.2"
      esutils: "^2.0.2"
      natural-compare: "^1.4.0"

```